### PR TITLE
Fix image URLs where a third party image host is used.

### DIFF
--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -261,7 +261,10 @@ class SeoMixin(Page):
         """
         base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_image:
-            return base_url + self.seo_image.get_rendition("original").url
+            seo_image_url = self.seo_image.get_rendition("original").url
+            if not seo_image_url.startswith('http'):
+                seo_image_url = base_url + seo_image_url
+            return seo_image_url
         return ""
 
     @property
@@ -280,7 +283,10 @@ class SeoMixin(Page):
         """
         base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_logo:
-            return base_url + self.seo_logo.get_rendition("original").url
+            seo_logo_url = self.seo_logo.get_rendition("original").url
+            if not seo_logo_url.startswith('http'):
+                seo_logo_url = base_url + seo_logo_url
+            return seo_logo_url
         return ""
 
     @property

--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -262,7 +262,7 @@ class SeoMixin(Page):
         base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_image:
             seo_image_url = self.seo_image.get_rendition("original").url
-            if not seo_image_url.startswith('http'):
+            if not utils.PROTOCOL_RE.match(seo_image_url):
                 seo_image_url = base_url + seo_image_url
             return seo_image_url
         return ""
@@ -284,7 +284,7 @@ class SeoMixin(Page):
         base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_logo:
             seo_logo_url = self.seo_logo.get_rendition("original").url
-            if not seo_logo_url.startswith('http'):
+            if not utils.PROTOCOL_RE.match(seo_logo_url):
                 seo_logo_url = base_url + seo_logo_url
             return seo_logo_url
         return ""

--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -259,12 +259,10 @@ class SeoMixin(Page):
         """
         Gets the absolute URL for the primary Open Graph image of this page.
         """
-        base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_image:
-            seo_image_url = self.seo_image.get_rendition("original").url
-            if not utils.PROTOCOL_RE.match(seo_image_url):
-                seo_image_url = base_url + seo_image_url
-            return seo_image_url
+            url = self.seo_image.get_rendition("original").url
+            base_url = utils.get_absolute_media_url(self.get_site())
+            return utils.ensure_absolute_url(url, base_url)
         return ""
 
     @property
@@ -281,12 +279,10 @@ class SeoMixin(Page):
         """
         Gets the absolute URL for the organization logo.
         """
-        base_url = utils.get_absolute_media_url(self.get_site())
         if self.seo_logo:
-            seo_logo_url = self.seo_logo.get_rendition("original").url
-            if not utils.PROTOCOL_RE.match(seo_logo_url):
-                seo_logo_url = base_url + seo_logo_url
-            return seo_logo_url
+            url = self.seo_logo.get_rendition("original").url
+            base_url = utils.get_absolute_media_url(self.get_site())
+            return utils.ensure_absolute_url(url, base_url)
         return ""
 
     @property

--- a/wagtailseo/utils.py
+++ b/wagtailseo/utils.py
@@ -43,6 +43,12 @@ def get_absolute_media_url(site: Site) -> str:
     return site.root_url
 
 
+def ensure_absolute_url(url: str, base_url: str) -> str:
+    if not PROTOCOL_RE.match(url):
+        url = base_url + url
+    return url
+
+
 def get_struct_data_images(site: Site, image: AbstractImage) -> List[str]:
     """
     Google requires multiple different aspect ratios for certain structured
@@ -54,14 +60,15 @@ def get_struct_data_images(site: Site, image: AbstractImage) -> List[str]:
     :rtype: List[str]
     :return: A list of absolute image URLs.
     """
+
     base_url = get_absolute_media_url(site)
 
     # Use huge numbers because Wagtail will not upscale, but will max out at the
     # image's original resolution using the specified aspect ratio.
     # Google wants them high resolution.
-    img1x1 = base_url + image.get_rendition("fill-10000x10000").url
-    img4x3 = base_url + image.get_rendition("fill-40000x30000").url
-    img16x9 = base_url + image.get_rendition("fill-16000x9000").url
+    img1x1 = ensure_absolute_url(image.get_rendition("fill-10000x10000").url, base_url)
+    img4x3 = ensure_absolute_url(image.get_rendition("fill-40000x30000").url, base_url)
+    img16x9 = ensure_absolute_url(image.get_rendition("fill-16000x9000").url, base_url)
 
     return [img1x1, img4x3, img16x9]
 


### PR DESCRIPTION
Running on Heroku with the Cloudinary image hosting library, I get this kind of image URL:

```
...
"logo": {"@type": "ImageObject", "url": "**https://domain.comhttps://res.cloudinary.com/**hcjegna1b/image/upload/v1/media/images/Artboard_1_copy_43x_oxrby8.original_qm49ea"}
...
```

So here's a quick fix to check if the rendition image is already a fully formed url.