### PR TITLE
 Fix for longitude and latitude with longer digits 

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+0.0.4
+-----
+
+*  Fix for longitude and latitude with longer digits. Now allowing longitude with 3 digits before the decimal point (e.g. +/- 100.12345)
+
 0.0.3
 -----
 

--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -140,14 +140,14 @@ class SeoMixin(Page):
     struct_org_geo_lat = models.DecimalField(
         blank=True,
         null=True,
-        max_digits=10,
+        max_digits=12,
         decimal_places=8,
         verbose_name=_("Geographic latitude"),
     )
     struct_org_geo_lng = models.DecimalField(
         blank=True,
         null=True,
-        max_digits=10,
+        max_digits=12,
         decimal_places=8,
         verbose_name=_("Geographic longitude"),
     )

--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -140,14 +140,14 @@ class SeoMixin(Page):
     struct_org_geo_lat = models.DecimalField(
         blank=True,
         null=True,
-        max_digits=12,
+        max_digits=11,
         decimal_places=8,
         verbose_name=_("Geographic latitude"),
     )
     struct_org_geo_lng = models.DecimalField(
         blank=True,
         null=True,
-        max_digits=12,
+        max_digits=11,
         decimal_places=8,
         verbose_name=_("Geographic longitude"),
     )


### PR DESCRIPTION
Now allowing longitude with 3 digits before the decimal point (e.g. +/- 100.12345)
