### PR TITLE
Add Twitter description meta tag

### DIFF
--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -161,6 +161,7 @@ class SeoTest(TestCase):
                 <meta name="twitter:card" content="{ page.seo_twitter_card_content }" />
                 <meta name="twitter:title" content="{ page.seo_pagetitle }">
                 <meta name="twitter:image" content="{ page.seo_image_url }">
+                <meta name="twitter:description" content="{ page.seo_description }" />
                 <meta name="twitter:site" content="{ seo_set.at_twitter_site }" />
                 <link rel="amphtml" href="{ page.seo_amp_url }">
                 </head>
@@ -197,6 +198,7 @@ class SeoTest(TestCase):
             <meta name="twitter:card" content="{ page.seo_twitter_card_content }" />
             <meta name="twitter:title" content="{ page.seo_pagetitle }">
             <meta name="twitter:image" content="{ page.seo_image_url }">
+            <meta name="twitter:description" content="{ page.seo_description }" />
             <meta name="twitter:site" content="{ seo_set.at_twitter_site }" />
             <link rel="amphtml" href="{ page.seo_amp_url }">
             </head>

--- a/wagtailseo/templates/wagtailseo/meta.html
+++ b/wagtailseo/templates/wagtailseo/meta.html
@@ -35,6 +35,7 @@
 <meta name="twitter:card" content="{% block twitter_card %}{{ self.seo_twitter_card_content }}{% endblock %}" />
 <meta name="twitter:title" content="{% block twitter_title %}{{ self.seo_pagetitle }}{% endblock %}">
 <meta name="twitter:image" content="{% block twitter_image %}{{ self.seo_image_url }}{% endblock %}">
+<meta name="twitter:description" content="{% block twitter_description %}{{ self.seo_description }}{% endblock %}">
 <meta name="twitter:site" content="{% block twitter_site %}{{ settings.wagtailseo.SeoSettings.at_twitter_site }}{% endblock %}" />
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
I saw that the twitter description is missing in the list of meta tags. Also on Social Share Preview the Twitter description test fails with the following message:
**The twitter:description metatag is missing (falling back to description)**