### PR TITLE
Added check for getting site name from empty site object

### DIFF
--- a/wagtailseo/models.py
+++ b/wagtailseo/models.py
@@ -294,7 +294,9 @@ class SeoMixin(Page):
         Gets the site name.
         Override in your Page model as necessary.
         """
-        return self.get_site().site_name
+        if self.get_site():
+            return self.get_site().site_name
+        return ""
 
     @property
     def seo_pagetitle(self) -> str:


### PR DESCRIPTION
Created this PR for the opened issue linked below:
https://github.com/coderedcorp/wagtail-seo/issues/32#issue-1110574602

Added check at seo_sitename method that returns the site name. In case wagtail-seo can not get the site object, getting site name throws error, instead of returning some empty string as fallback option.