### PR TITLE
Only render SEO meta tags if a page object is present in the template context

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,12 @@ Release Notes
 =============
 
 
+2.0.1
+-----
+
+* Only render SEO meta tags if a page object is present in the template context.
+
+
 2.0.0
 -----
 
@@ -12,6 +18,12 @@ Release Notes
 
 * Supports Wagtail 3 and only Wagtail 3. Wagtail 2 support will be maintained in
   the 1.x series as needed.
+
+
+1.0.1
+-----
+
+* Only render SEO meta tags if a page object is present in the template context.
 
 
 1.0.0

--- a/wagtailseo/templates/wagtailseo/meta.html
+++ b/wagtailseo/templates/wagtailseo/meta.html
@@ -1,3 +1,6 @@
+{# Only render this template if we have what appears to be a wagtail-seo page #}
+{% if self and self.seo_pagetitle %}
+
 {# Standard metadata #}
 {% block html_seo_base %}
 <title>{% block title %}{{ self.seo_pagetitle }}{% endblock %}</title>
@@ -39,3 +42,5 @@
 {% endif %}
 {% endblock %}
 {% block twitter_seo_extra %}{% endblock %}
+
+{% endif %}


### PR DESCRIPTION
Otherwise, if the meta.html template is included in a template which does not have a page object (such as a re-usable base.html template) it will spew out a bunch of useless empty tags.