### PR TITLE
Allow compatibility with Wagtail 4.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     packages=["wagtailseo"],
     python_requires=">=3.6",
-    install_requires=["wagtail>=3.0,<4.0"],
+    install_requires=["wagtail>=3.0,<=4.0"],
     classifiers=[
         "Framework :: Django",
         "Framework :: Wagtail",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     packages=["wagtailseo"],
     python_requires=">=3.6",
-    install_requires=["wagtail>=3.0,<=4.0"],
+    install_requires=["wagtail>=3.0,<=4.1"],
     classifiers=[
         "Framework :: Django",
         "Framework :: Wagtail",

--- a/wagtailseo/__init__.py
+++ b/wagtailseo/__init__.py
@@ -1,3 +1,3 @@
-release = ["2", "2", "0"]
+release = ["2", "2", "1"]
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])


### PR DESCRIPTION
The current version 2.2.0 works well with Wagtail 4, except for configuration which disallows W4.
Suggested changes:
* Bumped version to 2.2.1. 
* Changed requirements to Wagtail <=4.0