### PR TITLE
Upgrade Wagtail version to 5.0, drop older versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py38', 'py39', 'py310', 'py311']
 # Regular expression of files to exclude.
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=["wagtailseo"],
-    python_requires=">=3.6",
-    install_requires=["wagtail>=3.0,<5.0"],
+    python_requires=">=3.9",
+    install_requires=["wagtail>=5.0,<6.0"],
     classifiers=[
         "Framework :: Django",
         "Framework :: Wagtail",

--- a/wagtailseo/__init__.py
+++ b/wagtailseo/__init__.py
@@ -1,3 +1,3 @@
-release = ["2", "3", "0"]
+release = ["5", "0", "0"]
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])


### PR DESCRIPTION
* Upgrade Wagtail Version to 5.0
* Adjust python versions to supported versions (3.8 - 3.11)
* Bump version number to match wagtail version.